### PR TITLE
Write to BQ Native Tables

### DIFF
--- a/leanplum_data_export/export.py
+++ b/leanplum_data_export/export.py
@@ -194,7 +194,9 @@ class LeanplumExporter(object):
             else:
                 sql = f"INSERT INTO `{dataset}.{table_name}` {select_sql}"
 
-            logging.info(f"Inserting into native table {dataset}.{table_name} from {ext_dataset}.{ext_table_name}")
+            logging.info((
+                f"Inserting into native table {dataset}.{table_name} "
+                f"from {ext_dataset}.{ext_table_name}"))
             logging.info(sql)
 
             job = self.bq_client.query(sql)
@@ -213,11 +215,11 @@ class LeanplumExporter(object):
             self.bq_client.delete_table(table)
 
     def get_table_exists(self, table):
-       try:
-           table = self.bq_client.get_table(table)
-           return True
-       except exceptions.NotFound:
-           return False
+        try:
+            table = self.bq_client.get_table(table)
+            return True
+        except exceptions.NotFound:
+            return False
 
     def get_table_name(self, table_prefix, leanplum_name, version, date=None):
         if table_prefix:

--- a/tests/test_leanplum_export.py
+++ b/tests/test_leanplum_export.py
@@ -248,7 +248,6 @@ class TestExporter(object):
         with patch('leanplum_data_export.export.bigquery', spec=True) as MockBq:
             with patch('leanplum_data_export.export.storage', spec=True) as MockStorage:
                 mock_bucket, mock_client, mock_blob = Mock(), Mock(), Mock()
-                mock_job_config = Mock()
 
                 mock_client.list_blobs.side_effect = [[]]
                 mock_client.bucket.return_value = mock_bucket
@@ -291,7 +290,8 @@ class TestExporter(object):
                 MockBq.TableReference.assert_any_call(mock_dataset_ref, "sessions_v1")
 
                 delete_query = (
-                    f"DELETE FROM `{dataset_name}.sessions_v1` WHERE load_date = PARSE_DATE('%Y%m%d', '{date}')")
+                    f"DELETE FROM `{dataset_name}.sessions_v1` "
+                    f"WHERE load_date = PARSE_DATE('%Y%m%d', '{date}')")
                 mock_bq_client.query.assert_any_call(delete_query)
 
                 expected_query = (
@@ -303,7 +303,7 @@ class TestExporter(object):
                 mock_bq_client.delete_table.assert_any_call(mock_table)
 
     @responses.activate
-    def test_export_new_table(self, exporter):
+    def test_export_existing_table(self, exporter):
         date = "20190101"
         job_id = "testjobid"
         file_uris = [('https://leanplum_export.storage.googleapis.com/export'
@@ -339,7 +339,6 @@ class TestExporter(object):
         with patch('leanplum_data_export.export.bigquery', spec=True) as MockBq:
             with patch('leanplum_data_export.export.storage', spec=True) as MockStorage:
                 mock_bucket, mock_client, mock_blob = Mock(), Mock(), Mock()
-                mock_job_config = Mock()
 
                 mock_client.list_blobs.side_effect = [[]]
                 mock_client.bucket.return_value = mock_bucket
@@ -381,7 +380,8 @@ class TestExporter(object):
                 MockBq.TableReference.assert_any_call(mock_dataset_ref, "sessions_v1")
 
                 delete_query = (
-                    f"DELETE FROM `{dataset_name}.sessions_v1` WHERE load_date = PARSE_DATE('%Y%m%d', '{date}')")
+                    f"DELETE FROM `{dataset_name}.sessions_v1` "
+                    f"WHERE load_date = PARSE_DATE('%Y%m%d', '{date}')")
                 mock_bq_client.query.assert_any_call(delete_query)
 
                 insert_query = (

--- a/tests/test_leanplum_export.py
+++ b/tests/test_leanplum_export.py
@@ -6,6 +6,7 @@ import re
 
 from unittest.mock import patch, Mock
 from leanplum_data_export.export import LeanplumExporter
+from google.cloud import exceptions
 
 
 app_id = "appid"
@@ -84,30 +85,29 @@ class TestExporter(object):
              body=file_body,
              status=200)
 
-        with patch('leanplum_data_export.export.storage', spec=True) as MockStorage:
-            self.file_contents = None
+        self.file_contents = None
 
-            def set_contents(filename):
-                with open(filename, "rb") as f:
-                    self.file_contents = f.read()
+        def set_contents(filename):
+            with open(filename, "rb") as f:
+                self.file_contents = f.read()
 
-            mock_bucket, mock_client, mock_blob = Mock(), Mock(), Mock()
-            MockStorage.Client.return_value = mock_client
+        mock_bucket, mock_client, mock_blob = Mock(), Mock(), Mock()
 
-            mock_client.list_blobs.side_effect = [[]]
-            mock_client.bucket.return_value = mock_bucket
-            mock_bucket.blob.return_value = mock_blob
-            mock_blob.upload_from_filename.side_effect = set_contents
+        mock_client.list_blobs.side_effect = [[]]
+        mock_client.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+        mock_blob.upload_from_filename.side_effect = set_contents
 
-            exporter.save_files(file_uris, bucket, prefix, date, "json", 1)
+        exporter.gcs_client = mock_client
+        exporter.save_files(file_uris, bucket, prefix, date, "json", 1)
 
-            suffix = f"sessions/0.json"
-            mock_client.bucket.assert_called_with(bucket)
-            mock_bucket.blob.assert_called_with(f"{prefix}/v1/{date}/{suffix}")
-            mock_blob.upload_from_filename.assert_called_with(suffix)
-            assert self.file_contents == file_body
-            assert not os.path.isfile(suffix)
-            assert not os.path.isdir("sessions")
+        suffix = f"sessions/0.json"
+        mock_client.bucket.assert_called_with(bucket)
+        mock_bucket.blob.assert_called_with(f"{prefix}/v1/{date}/{suffix}")
+        mock_blob.upload_from_filename.assert_called_with(suffix)
+        assert self.file_contents == file_body
+        assert not os.path.isfile(suffix)
+        assert not os.path.isdir("sessions")
 
     @responses.activate
     def test_save_files_no_prefix(self, exporter):
@@ -124,30 +124,29 @@ class TestExporter(object):
              body=file_body,
              status=200)
 
-        with patch('leanplum_data_export.export.storage', spec=True) as MockStorage:
-            self.file_contents = None
+        self.file_contents = None
 
-            def set_contents(filename):
-                with open(filename, "rb") as f:
-                    self.file_contents = f.read()
+        def set_contents(filename):
+            with open(filename, "rb") as f:
+                self.file_contents = f.read()
 
-            mock_bucket, mock_client, mock_blob = Mock(), Mock(), Mock()
-            MockStorage.Client.return_value = mock_client
+        mock_bucket, mock_client, mock_blob = Mock(), Mock(), Mock()
 
-            mock_client.list_blobs.side_effect = [[]]
-            mock_client.bucket.return_value = mock_bucket
-            mock_bucket.blob.return_value = mock_blob
-            mock_blob.upload_from_filename.side_effect = set_contents
+        mock_client.list_blobs.side_effect = [[]]
+        mock_client.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+        mock_blob.upload_from_filename.side_effect = set_contents
 
-            exporter.save_files(file_uris, bucket, prefix, date, "json", 1)
+        exporter.gcs_client = mock_client
+        exporter.save_files(file_uris, bucket, prefix, date, "json", 1)
 
-            suffix = f"sessions/0.json"
-            mock_client.bucket.assert_called_with(bucket)
-            mock_bucket.blob.assert_called_with(f"v1/{date}/{suffix}")
-            mock_blob.upload_from_filename.assert_called_with(suffix)
-            assert self.file_contents == file_body
-            assert not os.path.isfile(suffix)
-            assert not os.path.isdir("sessions")
+        suffix = f"sessions/0.json"
+        mock_client.bucket.assert_called_with(bucket)
+        mock_bucket.blob.assert_called_with(f"v1/{date}/{suffix}")
+        mock_blob.upload_from_filename.assert_called_with(suffix)
+        assert self.file_contents == file_body
+        assert not os.path.isfile(suffix)
+        assert not os.path.isdir("sessions")
 
     @responses.activate
     def test_save_files_multiple_uris(self, exporter):
@@ -167,33 +166,32 @@ class TestExporter(object):
              body=file_body,
              status=200)
 
-        with patch('leanplum_data_export.export.storage', spec=True) as MockStorage:
-            self.file_contents = None
+        self.file_contents = None
 
-            def set_contents(filename):
-                with open(filename, "rb") as f:
-                    self.file_contents = f.read()
+        def set_contents(filename):
+            with open(filename, "rb") as f:
+                self.file_contents = f.read()
 
-            mock_bucket, mock_client, mock_blob = Mock(), Mock(), Mock()
-            MockStorage.Client.return_value = mock_client
+        mock_bucket, mock_client, mock_blob = Mock(), Mock(), Mock()
 
-            mock_client.list_blobs.side_effect = [["hello/world"]]
-            mock_client.bucket.return_value = mock_bucket
-            mock_bucket.blob.return_value = mock_blob
-            mock_blob.upload_from_filename.side_effect = set_contents
+        mock_client.list_blobs.side_effect = [["hello/world"]]
+        mock_client.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+        mock_blob.upload_from_filename.side_effect = set_contents
 
-            tables = exporter.save_files(file_uris, bucket, prefix, date, "json", 1)
-            mock_client.bucket.assert_called_with(bucket)
-            assert tables == set(file_types)
+        exporter.gcs_client = mock_client
+        tables = exporter.save_files(file_uris, bucket, prefix, date, "json", 1)
+        mock_client.bucket.assert_called_with(bucket)
+        assert tables == set(file_types)
 
-            for ftype in file_types:
-                for i in range(n_files):
-                    suffix = f"{ftype}/{i}.json"
-                    mock_bucket.blob.assert_any_call(f"v1/{date}/{suffix}")
-                    mock_blob.upload_from_filename.assert_any_call(suffix)
-                    assert self.file_contents == file_body
-                    assert not os.path.isfile(suffix)
-                    assert not os.path.isdir(ftype)
+        for ftype in file_types:
+            for i in range(n_files):
+                suffix = f"{ftype}/{i}.json"
+                mock_bucket.blob.assert_any_call(f"v1/{date}/{suffix}")
+                mock_blob.upload_from_filename.assert_any_call(suffix)
+                assert self.file_contents == file_body
+                assert not os.path.isfile(suffix)
+                assert not os.path.isdir(ftype)
 
     @responses.activate
     def test_save_files_improper_file_format(self, exporter):
@@ -210,12 +208,11 @@ class TestExporter(object):
              body=file_body,
              status=200)
 
-        with patch('leanplum_data_export.export.storage', spec=True) as MockStorage: # noqa F841
-            with pytest.raises(Exception):
-                exporter.save_files(file_uris, bucket, prefix, date, "json", 1)
+        with pytest.raises(Exception):
+            exporter.save_files(file_uris, bucket, prefix, date, "json", 1)
 
     @responses.activate
-    def test_export(self, exporter):
+    def test_export_new_table(self, exporter):
         date = "20190101"
         job_id = "testjobid"
         file_uris = [('https://leanplum_export.storage.googleapis.com/export'
@@ -223,6 +220,7 @@ class TestExporter(object):
         bucket = 'abucket'
         prefix = 'aprefix'
         file_body = b"data"
+        tmp_dataset = "tmp"
         dataset_name = "leanplum_dataset"
 
         responses.add(
@@ -241,22 +239,113 @@ class TestExporter(object):
             body=file_body,
             status=200)
 
+        self.file_contents = None
+
+        def set_contents(filename):
+            with open(filename, "rb") as f:
+                self.file_contents = f.read()
+
         with patch('leanplum_data_export.export.bigquery', spec=True) as MockBq:
             with patch('leanplum_data_export.export.storage', spec=True) as MockStorage:
-                self.file_contents = None
-
-                def set_contents(filename):
-                    with open(filename, "rb") as f:
-                        self.file_contents = f.read()
-
                 mock_bucket, mock_client, mock_blob = Mock(), Mock(), Mock()
-
-                MockStorage.Client.return_value = mock_client
+                mock_job_config = Mock()
 
                 mock_client.list_blobs.side_effect = [[]]
                 mock_client.bucket.return_value = mock_bucket
                 mock_bucket.blob.return_value = mock_blob
                 mock_blob.upload_from_filename.side_effect = set_contents
+                MockStorage.Client.return_value = mock_client
+
+                mock_bq_client, mock_dataset_ref = Mock(), Mock()
+                mock_table_ref, mock_table, mock_config = Mock(), Mock(), Mock()
+                mock_bq_client.dataset.return_value = mock_dataset_ref
+                mock_bq_client.get_table.side_effect = exceptions.NotFound('')
+                MockBq.Client.return_value = mock_bq_client
+                MockBq.TableReference.return_value = mock_table_ref
+                MockBq.Table.return_value = mock_table
+                MockBq.ExternalConfig.return_value = mock_config
+
+                exporter.export(date, bucket, prefix, dataset_name, "", 1, "test-project")
+
+                suffix = f"sessions/0.csv"
+                mock_client.bucket.assert_called_with(bucket)
+                mock_bucket.blob.assert_called_with(f"{prefix}/v1/{date}/{suffix}")
+                mock_blob.upload_from_filename.assert_called_with(suffix)
+                assert self.file_contents == file_body
+                assert not os.path.isfile(suffix)
+                assert not os.path.isdir("sessions")
+
+                mock_bq_client.dataset.assert_any_call(tmp_dataset)
+                mock_bq_client.delete_table.assert_any_call(mock_table, not_found_ok=True)
+                MockBq.TableReference.assert_any_call(mock_dataset_ref, f"sessions_v1_{date}")
+                MockBq.Table.assert_any_call(mock_table_ref)
+                MockBq.ExternalConfig.assert_any_call("CSV")
+
+                expected_source_uris = [f"gs://{bucket}/{prefix}/v1/{date}/sessions/*"]
+                assert mock_config.source_uris == expected_source_uris
+                assert mock_config.autodetect is True
+                assert mock_table.external_data_configuration == mock_config
+                mock_bq_client.create_table.assert_any_call(mock_table)
+
+                mock_bq_client.dataset.assert_any_call(dataset_name)
+                MockBq.TableReference.assert_any_call(mock_dataset_ref, "sessions_v1")
+
+                delete_query = (
+                    f"DELETE FROM `{dataset_name}.sessions_v1` WHERE load_date = PARSE_DATE('%Y%m%d', '{date}')")
+                mock_bq_client.query.assert_any_call(delete_query)
+
+                expected_query = (
+                    f"CREATE TABLE `{dataset_name}.sessions_v1` "
+                    f"PARTITION BY load_date AS SELECT * EXCEPT (lat,lon), "
+                    f"PARSE_DATE('%Y%m%d', '{date}') AS load_date FROM `tmp.sessions_v1_{date}`")
+                mock_bq_client.query.assert_any_call(expected_query)
+
+                mock_bq_client.delete_table.assert_any_call(mock_table)
+
+    @responses.activate
+    def test_export_new_table(self, exporter):
+        date = "20190101"
+        job_id = "testjobid"
+        file_uris = [('https://leanplum_export.storage.googleapis.com/export'
+                      '-5094741967896576-60c43e66-30fe-4e21-9bbd-563d2749b96f-outputsessions-0')]
+        bucket = 'abucket'
+        prefix = 'aprefix'
+        file_body = b"data"
+        tmp_dataset = "tmp"
+        dataset_name = "leanplum_dataset"
+
+        responses.add(
+            responses.GET,
+            'http://www.leanplum.com/api',
+            json={"response": [{"jobId": job_id}]},
+            status=200)
+        responses.add(
+            responses.GET,
+            'http://www.leanplum.com/api',
+            json={"response": [{"state": "FINISHED", "files": file_uris}]},
+            status=200)
+        responses.add(
+            responses.GET,
+            re.compile(r"https://leanplum_export.storage.googleapis.com.*"),
+            body=file_body,
+            status=200)
+
+        self.file_contents = None
+
+        def set_contents(filename):
+            with open(filename, "rb") as f:
+                self.file_contents = f.read()
+
+        with patch('leanplum_data_export.export.bigquery', spec=True) as MockBq:
+            with patch('leanplum_data_export.export.storage', spec=True) as MockStorage:
+                mock_bucket, mock_client, mock_blob = Mock(), Mock(), Mock()
+                mock_job_config = Mock()
+
+                mock_client.list_blobs.side_effect = [[]]
+                mock_client.bucket.return_value = mock_bucket
+                mock_bucket.blob.return_value = mock_blob
+                mock_blob.upload_from_filename.side_effect = set_contents
+                MockStorage.Client.return_value = mock_client
 
                 mock_bq_client, mock_dataset_ref = Mock(), Mock()
                 mock_table_ref, mock_table, mock_config = Mock(), Mock(), Mock()
@@ -276,8 +365,8 @@ class TestExporter(object):
                 assert not os.path.isfile(suffix)
                 assert not os.path.isdir("sessions")
 
-                mock_bq_client.dataset.assert_any_call(dataset_name)
-                mock_bq_client.delete_table.assert_called_with(mock_table, not_found_ok=True)
+                mock_bq_client.dataset.assert_any_call(tmp_dataset)
+                mock_bq_client.delete_table.assert_any_call(mock_table, not_found_ok=True)
                 MockBq.TableReference.assert_any_call(mock_dataset_ref, f"sessions_v1_{date}")
                 MockBq.Table.assert_any_call(mock_table_ref)
                 MockBq.ExternalConfig.assert_any_call("CSV")
@@ -288,13 +377,28 @@ class TestExporter(object):
                 assert mock_table.external_data_configuration == mock_config
                 mock_bq_client.create_table.assert_any_call(mock_table)
 
+                mock_bq_client.dataset.assert_any_call(dataset_name)
+                MockBq.TableReference.assert_any_call(mock_dataset_ref, "sessions_v1")
+
+                delete_query = (
+                    f"DELETE FROM `{dataset_name}.sessions_v1` WHERE load_date = PARSE_DATE('%Y%m%d', '{date}')")
+                mock_bq_client.query.assert_any_call(delete_query)
+
+                insert_query = (
+                    f"INSERT INTO `{dataset_name}.sessions_v1` SELECT * EXCEPT (lat,lon), "
+                    f"PARSE_DATE('%Y%m%d', '{date}') AS load_date FROM `tmp.sessions_v1_{date}`")
+                mock_bq_client.query.assert_any_call(insert_query)
+
+                mock_bq_client.delete_table.assert_any_call(mock_table)
+
     def test_delete_gcs_prefix(self, exporter):
         client, bucket = Mock(), Mock()
         blobs = ["hello/world"]
         prefix = "hello"
         client.list_blobs.side_effect = [blobs]
 
-        exporter.delete_gcs_prefix(client, bucket, prefix)
+        exporter.gcs_client = client
+        exporter.delete_gcs_prefix(bucket, prefix)
 
         client.list_blobs.assert_called_with(bucket, prefix=prefix, max_results=1000)
         bucket.delete_blobs.assert_called_with(blobs)
@@ -325,8 +429,9 @@ class TestExporter(object):
             MockBq.Table.return_value = mock_table
             MockBq.ExternalConfig.return_value = mock_config
 
+            exporter.bq_client = mock_bq_client
             exporter.create_external_tables(
-                bucket, prefix, date, tables, "test-project", dataset_name, table_prefix, 1)
+                bucket, prefix, date, tables, dataset_name, table_prefix, 1)
 
             mock_bq_client.dataset.assert_any_call(dataset_name)
             mock_bq_client.delete_table.assert_called_with(mock_table, not_found_ok=True)


### PR DESCRIPTION
See bug 1593268.
- Add an option for removing columns before load
- Partition table based on load date
- Delete partition before loading
- Create table on first load
- Move clients to be class vars
- Update tests

I will note the tests no longer cover these as well, but it's basically a few API calls.
I've tested this on my dev project with firefox nightly:
- Tested a first run (create tables)
- Tested a consecutive run (append data)
- Tested a duplicate run (delete existing data)

Everything looks good so far.