### PR TITLE
Allow quoted newlines un csv load (fixes #10)

### DIFF
--- a/leanplum_data_export/export.py
+++ b/leanplum_data_export/export.py
@@ -148,7 +148,8 @@ class LeanplumExporter(object):
             external_config = bigquery.ExternalConfig('CSV')
             external_config.source_uris = [f"{gcs_loc}/{leanplum_name}/*"]
             external_config.autodetect = True
-            external_config.options.allow_jagged_rows = True
+            #external_config.options.allow_jagged_rows = True
+            external_config.options.allow_quoted_newlines = True
 
             table.external_data_configuration = external_config
 

--- a/leanplum_data_export/export.py
+++ b/leanplum_data_export/export.py
@@ -148,6 +148,7 @@ class LeanplumExporter(object):
             external_config = bigquery.ExternalConfig('CSV')
             external_config.source_uris = [f"{gcs_loc}/{leanplum_name}/*"]
             external_config.autodetect = True
+            external_config.options.allow_jagged_rows = True
 
             table.external_data_configuration = external_config
 

--- a/leanplum_data_export/export.py
+++ b/leanplum_data_export/export.py
@@ -148,7 +148,6 @@ class LeanplumExporter(object):
             external_config = bigquery.ExternalConfig('CSV')
             external_config.source_uris = [f"{gcs_loc}/{leanplum_name}/*"]
             external_config.autodetect = True
-            #external_config.options.allow_jagged_rows = True
             external_config.options.allow_quoted_newlines = True
 
             table.external_data_configuration = external_config


### PR DESCRIPTION
Running the task on the date that was failing now works:
![Screen Shot 2019-12-18 at 12 53 43 PM](https://user-images.githubusercontent.com/12437227/71110515-71b8c680-2195-11ea-82e7-3a332fe51aec.png)

I confirmed it was failing before.

The problematic row can now be read: https://sql.telemetry.mozilla.org/queries/67136/source