### PR TITLE
Set lower chunksize for upload to gcs

### DIFF
--- a/leanplum_data_export/export.py
+++ b/leanplum_data_export/export.py
@@ -119,6 +119,7 @@ class LeanplumExporter(object):
 
         logging.info(f"Uploading {file_name} to gs://{gcs_path}")
         # set lower chunksize to avoid timeouts after 60s while uploading chunks (default is 100MB)
+        # More details here: https://github.com/googleapis/python-storage/issues/74
         blob = self.gcs_client.bucket(bucket).blob(gcs_path, chunk_size=1024*1024*50)
         blob.upload_from_filename(str(file_path))
 

--- a/leanplum_data_export/export.py
+++ b/leanplum_data_export/export.py
@@ -118,7 +118,8 @@ class LeanplumExporter(object):
         gcs_path = os.path.join(self.get_gcs_prefix(prefix, version, date, data_type), file_name)
 
         logging.info(f"Uploading {file_name} to gs://{gcs_path}")
-        blob = self.gcs_client.bucket(bucket).blob(gcs_path)
+        # set lower chunksize to avoid timeouts after 60s while uploading chunks (default is 100MB)
+        blob = self.gcs_client.bucket(bucket).blob(gcs_path, chunk_size=1024*1024*50)
         blob.upload_from_filename(str(file_path))
 
     def write_to_csv(self, csv_writers: Dict[str, csv.DictWriter], session_data: Dict,

--- a/tests/test_leanplum_export.py
+++ b/tests/test_leanplum_export.py
@@ -340,7 +340,7 @@ class TestStreamingExporter(object):
         exporter.gcs_client = mock_gcs
         exporter.write_to_gcs(Path("/a/b/c"), "sessions", "bucket", "firefox", "1", "20200601")
 
-        mock_bucket.blob.assert_called_once_with("firefox/v1/20200601/sessions/c")
+        mock_bucket.blob.assert_called_once_with("firefox/v1/20200601/sessions/c", chunk_size=ANY)
         mock_blob.upload_from_filename.assert_called_once_with("/a/b/c")
 
     @patch("google.cloud.storage.Client")
@@ -353,7 +353,7 @@ class TestStreamingExporter(object):
         exporter.write_to_gcs(Path("/a/b/c"), "sessions", "bucket", "firefox", "1", "20200601",
                               file_name="d")
 
-        mock_bucket.blob.assert_called_once_with("firefox/v1/20200601/sessions/d")
+        mock_bucket.blob.assert_called_once_with("firefox/v1/20200601/sessions/d", chunk_size=ANY)
         mock_blob.upload_from_filename.assert_called_once_with("/a/b/c")
 
     def test_write_to_csv_write_count(self, exporter, sample_data):


### PR DESCRIPTION
There have been some intermittent errors due to timeout during the upload to gcs.  The timeouts happen after exactly one minute and is likely the same issue as this https://github.com/googleapis/python-storage/issues/74
The timeout doesn't look to be configurable in the gcs sdk so reducing chunksize seems to be the only way to stay under the timeout